### PR TITLE
Interactive Commands

### DIFF
--- a/exec.js
+++ b/exec.js
@@ -1,7 +1,11 @@
 const execa = require('execa')
 
 module.exports = command => {
-  const {stdout, stderr} = execa(command, { shell: true, env: { FORCE_COLOR: true } });
+  const { stdout, stderr } = execa(command, {
+    shell: true,
+    stdin: 'inherit',
+    env: { FORCE_COLOR: true },
+  });
   stdout.pipe(process.stdout);
   stderr.pipe(process.stderr);
 }

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,5 +1,3 @@
-const { series: { nps: series }, concurrent: { nps: parallel } } = require('nps-utils')
-
 module.exports = {
   scripts: {
     default: 'echo default',

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "author": "siddharthkp",
   "license": "MIT",
   "dependencies": {
-    "execa": "~4.0.3",
+    "execa": "~6.0.0",
     "fuzzy": "0.1.3",
-    "inquirer": "~7.3.3",
-    "inquirer-autocomplete-prompt": "~1.0.2",
+    "inquirer": "~8.2.0",
+    "inquirer-autocomplete-prompt": "~1.4.0",
     "right-pad": "1.0.1",
     "nps": "~5.10.0",
     "nps-utils": "~1.7.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "inquirer": "~8.2.0",
     "inquirer-autocomplete-prompt": "~1.4.0",
     "right-pad": "1.0.1",
-    "nps": "~5.10.0",
-    "nps-utils": "~1.7.0"
+    "nps": "~5.10.0"
   }
 }

--- a/tools/workspace-scripts.js
+++ b/tools/workspace-scripts.js
@@ -1,5 +1,3 @@
-const { series: { nps: series }, concurrent: { nps: parallel } } = require('nps-utils')
-
 module.exports = {
   scripts: {
     default: 'echo default',


### PR DESCRIPTION
## Description

This updates the dependencies to their latest versions.
This removes `nps-utils` as it was never used (was only in development scripts)
This adds support for interactive commands that depend on stdin like commitizen